### PR TITLE
add CNAME for tmlt.dev

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+tmlt.dev


### PR DESCRIPTION
This is configuration for setting up tmlt.dev as a documentation website. As per Michael Hay, the DNS records on `tmlt.dev` have been updated.

Relevant documentation:
https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain

Adding tmlt.dev under "Custom domain" gives the error:

> Repository rule violations found Changes must be made through a pull request.

This PR manually adds a CNAME file instead. 

Alternatively, it may be possible to temporarily disable the rule, to allow configuration from the "Custom domain" UI.